### PR TITLE
updated lexical category mapping 

### DIFF
--- a/lib/wordnet/pos.rb
+++ b/lib/wordnet/pos.rb
@@ -1,3 +1,3 @@
 module WordNet
-  SynsetType = {"n" => "noun", "v" => "verb", "adj" => "adj", "adv" => "adv"}
+  SynsetType = {"n" => "noun", "v" => "verb", "a" => "adj", "r" => "adv"}
 end


### PR DESCRIPTION
previous mapping seemed wrong (admittedly from very brief test) -- for instance this failed before on synsets in the second line.

> > adjectives = WordNet::AdjectiveIndex.instance; nil
> > adjectives.find("tall").synsets.each {|x| p x.words};nil

it could not find the corresponding dictionary file since pos in Lemma was "a" and hence the dictionary file read from in the Synset constructor was "data.#{SynsetType[pos]}" == data.#{nil}
