### PR TITLE
Fix NameError in gemspec

### DIFF
--- a/rwordnet.gemspec
+++ b/rwordnet.gemspec
@@ -1,3 +1,4 @@
+require 'rake'
 require './lib/wordnet/version'
 
 Gem::Specification.new "rwordnet", WordNet::VERSION do |s|


### PR DESCRIPTION
Fix NameError in Ruby 2.2.0 (and possibly other Ruby versions). The error when installing rwordnet on Ruby 2.2.0:
    
    There was a NameError while loading rwordnet.gemspec: 
    uninitialized constant FileList